### PR TITLE
Multi source listeners

### DIFF
--- a/Packages/com.chark.scriptable-events/Editor/BaseScriptableEventListenerEditor.cs
+++ b/Packages/com.chark.scriptable-events/Editor/BaseScriptableEventListenerEditor.cs
@@ -1,4 +1,4 @@
-﻿using UnityEditor;
+using UnityEditor;
 
 namespace ScriptableEvents.Editor
 {
@@ -22,10 +22,10 @@ namespace ScriptableEvents.Editor
 
         // Serialized properties.
 #if ODIN_INSPECTOR
-        private Sirenix.OdinInspector.Editor.InspectorProperty scriptableEventProperty;
+        private Sirenix.OdinInspector.Editor.InspectorProperty scriptableEventsProperty;
         private Sirenix.OdinInspector.Editor.InspectorProperty onRaisedProperty;
 #else
-        private SerializedProperty scriptableEventProperty;
+        private SerializedProperty scriptableEventsProperty;
         private SerializedProperty onRaisedProperty;
 #endif
 
@@ -54,7 +54,7 @@ namespace ScriptableEvents.Editor
             EditorGUI.BeginChangeCheck();
 #endif
 
-            DrawScriptableEvent();
+            DrawScriptableEvents();
             DrawOnRaised();
 
 #if ODIN_INSPECTOR
@@ -73,12 +73,12 @@ namespace ScriptableEvents.Editor
 
         private void SetupEditor()
         {
-            SetupBaseScriptableEventListener();
+            SetupBaseScriptableEventsListener();
             SetupMonoScript();
             SetupSerializedProperties();
         }
 
-        private void SetupBaseScriptableEventListener()
+        private void SetupBaseScriptableEventsListener()
         {
             baseScriptableEventListener = target as BaseScriptableEventListener;
         }
@@ -91,10 +91,10 @@ namespace ScriptableEvents.Editor
         private void SetupSerializedProperties()
         {
 #if ODIN_INSPECTOR
-            scriptableEventProperty = Tree.GetPropertyAtPath("scriptableEvent");
+            scriptableEventsProperty = Tree.GetPropertyAtPath("scriptableEvents");
             onRaisedProperty = Tree.GetPropertyAtPath("onRaised");
 #else
-            scriptableEventProperty = serializedObject.FindProperty("scriptableEvent");
+            scriptableEventsProperty = serializedObject.FindProperty("scriptableEvents");
             onRaisedProperty = serializedObject.FindProperty("onRaised");
 #endif
         }
@@ -108,12 +108,12 @@ namespace ScriptableEvents.Editor
             ScriptableEventGUI.MonoScriptField(monoScript);
         }
 
-        private void DrawScriptableEvent()
+        private void DrawScriptableEvents()
         {
 #if ODIN_INSPECTOR
-            scriptableEventProperty.Draw();
+            scriptableEventsProperty.Draw();
 #else
-            EditorGUILayout.PropertyField(scriptableEventProperty);
+            EditorGUILayout.PropertyField(scriptableEventsProperty);
 #endif
         }
 

--- a/Packages/com.chark.scriptable-events/Runtime/BaseScriptableEventListener.cs
+++ b/Packages/com.chark.scriptable-events/Runtime/BaseScriptableEventListener.cs
@@ -38,12 +38,12 @@ namespace ScriptableEvents
         {
             // No null or empty check - a listener can exist with that is listening to nothing.
             // This also avoids issues on initialisation
-            scriptableEvents?.ForEach(scriptableEvent => scriptableEvent.AddListener(this));
+            scriptableEvents.ForEach(scriptableEvent => scriptableEvent.AddListener(this));
         }
 
         private void OnDisable()
         {
-            scriptableEvents?.ForEach(scriptableEvent => scriptableEvent.RemoveListener(this));
+            scriptableEvents.ForEach(scriptableEvent => scriptableEvent.RemoveListener(this));
         }
 
         #endregion
@@ -58,8 +58,11 @@ namespace ScriptableEvents
         public void OnBeforeSerialize()
         {
             // Move from the old single event model to the new model.
-            // Ideally we should only do this in Editor mode but Application.isPlaying will not work during serialisation 
-            if (scriptableEvent != null)
+            if (Application.isPlaying)
+            {
+                return;
+            }
+            if (scriptableEvent!=false)
             {
                 if (!scriptableEvents.Contains(scriptableEvent))
                 {

--- a/Packages/com.chark.scriptable-events/Runtime/BaseScriptableEventListener.cs
+++ b/Packages/com.chark.scriptable-events/Runtime/BaseScriptableEventListener.cs
@@ -1,4 +1,6 @@
-﻿using UnityEngine;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
 using UnityEngine.Events;
 
 namespace ScriptableEvents
@@ -11,13 +13,18 @@ namespace ScriptableEvents
     /// Type of data which is passed as an argument to this listener
     /// </typeparam>
     public abstract class BaseScriptableEventListener<TArg>
-        : BaseScriptableEventListener, IScriptableEventListener<TArg>
+        : BaseScriptableEventListener, IScriptableEventListener<TArg>, ISerializationCallbackReceiver
     {
         #region Editor
-
+        [HideInInspector]
         [SerializeField]
+        [Obsolete]
         [Tooltip("ScriptableEvent that triggers the On Raised UnityEvent")]
         private BaseScriptableEvent<TArg> scriptableEvent;
+
+        [SerializeField]
+        [Tooltip("List of ScriptableEvents that trigger the On Raised UnityEvent")]
+        private List<BaseScriptableEvent<TArg>> scriptableEvents = new List<BaseScriptableEvent<TArg>>();
 
         [Space]
         [SerializeField]
@@ -29,24 +36,14 @@ namespace ScriptableEvents
 
         private void OnEnable()
         {
-            if (scriptableEvent == null)
-            {
-                Debug.LogError("ScriptableEvent is not assigned", this);
-                enabled = false;
-                return;
-            }
-
-            scriptableEvent.AddListener(this);
+            // No null or empty check - a listener can exist with that is listening to nothing.
+            // This also avoids issues on initialisation
+            scriptableEvents?.ForEach(scriptableEvent => scriptableEvent.AddListener(this));
         }
 
         private void OnDisable()
         {
-            if (scriptableEvent == null)
-            {
-                return;
-            }
-
-            scriptableEvent.RemoveListener(this);
+            scriptableEvents?.ForEach(scriptableEvent => scriptableEvent.RemoveListener(this));
         }
 
         #endregion
@@ -56,6 +53,24 @@ namespace ScriptableEvents
         public void OnRaised(TArg value)
         {
             onRaised.Invoke(value);
+        }
+
+        public void OnBeforeSerialize()
+        {
+            // Move from the old single event model to the new model.
+            // Ideally we should only do this in Editor mode but Application.isPlaying will not work during serialisation 
+            if (scriptableEvent != null)
+            {
+                if (!scriptableEvents.Contains(scriptableEvent))
+                {
+                    scriptableEvents.Add(scriptableEvent);
+                }
+                scriptableEvent = null;
+            }
+        }
+
+        public void OnAfterDeserialize()
+        {
         }
 
         #endregion

--- a/Packages/com.chark.scriptable-events/Tests/Editor/ScriptBuilderTest.cs
+++ b/Packages/com.chark.scriptable-events/Tests/Editor/ScriptBuilderTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using ScriptableEvents.Editor.ScriptCreation;
 
 namespace ScriptableEvents.Tests.Editor
@@ -6,6 +6,15 @@ namespace ScriptableEvents.Tests.Editor
     [TestFixture]
     internal class ScriptBuilderTest
     {
+        /// <summary>
+        /// Quick routine to make sure CRLF values (and CR values) are all treated as LF
+        /// This is relevant as this file may bin in either windows or mac format, as may the template.
+        /// </summary>
+        public string NormaliseCRs(string source)
+        {
+            return source.Replace("\r\n", "\n").Replace("\r", "\n");
+        }
+
         [Test]
         public void ShouldCreateScriptFromEventTemplate()
         {
@@ -43,7 +52,7 @@ namespace ScriptableEvents.Tests.Editor
                 .AddImport("ScriptableEvents")
                 .Build();
 
-            Assert.AreEqual(expectedContent, scriptContent);
+            Assert.AreEqual(NormaliseCRs(expectedContent), NormaliseCRs(scriptContent));
         }
 
         [Test]
@@ -81,7 +90,7 @@ namespace ScriptableEvents.Tests.Editor
                 .AddImport("ScriptableEvents")
                 .Build();
 
-            Assert.AreEqual(expectedContent, scriptContent);
+            Assert.AreEqual(NormaliseCRs(expectedContent), NormaliseCRs(scriptContent));
         }
 
         [Test]
@@ -123,7 +132,7 @@ namespace ScriptableEvents.Tests.Editor
                 .AddImport("ScriptableEvents.Editor")
                 .Build();
 
-            Assert.AreEqual(expectedContent, scriptContent);
+            Assert.AreEqual(NormaliseCRs(expectedContent), NormaliseCRs(scriptContent));
         }
     }
 }

--- a/Packages/com.chark.scriptable-events/Tests/Editor/ScriptBuilderTest.cs
+++ b/Packages/com.chark.scriptable-events/Tests/Editor/ScriptBuilderTest.cs
@@ -6,15 +6,6 @@ namespace ScriptableEvents.Tests.Editor
     [TestFixture]
     internal class ScriptBuilderTest
     {
-        /// <summary>
-        /// Quick routine to make sure CRLF values (and CR values) are all treated as LF
-        /// This is relevant as this file may bin in either windows or mac format, as may the template.
-        /// </summary>
-        public string NormaliseCRs(string source)
-        {
-            return source.Replace("\r\n", "\n").Replace("\r", "\n");
-        }
-
         [Test]
         public void ShouldCreateScriptFromEventTemplate()
         {
@@ -134,5 +125,15 @@ namespace ScriptableEvents.Tests.Editor
 
             Assert.AreEqual(NormaliseCRs(expectedContent), NormaliseCRs(scriptContent));
         }
+
+        /// <summary>
+        /// Helper routine to make sure CRLF values (and CR values) are all treated as LF
+        /// This is relevant as this file may be in either windows or mac/unix format, as may the template.
+        /// </summary>
+        private static string NormaliseCRs(string source)
+        {
+            return source.Replace("\r\n", "\n").Replace("\r", "\n");
+        }
+
     }
 }

--- a/Packages/com.chark.scriptable-events/Tests/Runtime/ReflectionUtils.cs
+++ b/Packages/com.chark.scriptable-events/Tests/Runtime/ReflectionUtils.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+using System.Collections.Generic;
+using System.Reflection;
 
 namespace ScriptableEvents.Tests.Runtime
 {
@@ -20,6 +21,16 @@ namespace ScriptableEvents.Tests.Runtime
         {
             var field = obj.GetField(name);
             field.SetValue(obj, value);
+        }
+        /// <summary>
+        /// Add an item to a field of type List<T>
+        /// </summary>
+        internal static void AddToListField<T>(this object obj, string name, T value)
+        {
+            var field = obj.GetField(name);
+            var fieldValue = (List<T>)field.GetValue(obj);
+            fieldValue.Add(value);
+            field.SetValue(obj, fieldValue);
         }
 
         #endregion

--- a/Packages/com.chark.scriptable-events/Tests/Runtime/ScriptableEventTest.cs
+++ b/Packages/com.chark.scriptable-events/Tests/Runtime/ScriptableEventTest.cs
@@ -23,6 +23,7 @@ namespace ScriptableEvents.Tests.Runtime
 
         private List<TArg> capturedArgs;
         private TScriptableEvent scriptableEvent;
+        private TScriptableEvent scriptableEvent2; // Not used in most tests.
         private UnityEvent<TArg> unityEvent;
         private TScriptableEventListener scriptableEventListener;
 
@@ -39,7 +40,7 @@ namespace ScriptableEvents.Tests.Runtime
         public void SetUp()
         {
             SetupRaisedArgs();
-            SetupScriptableEvent();
+            SetupScriptableEvents();
             SetupUnityEvent();
             SetupScriptableEventListener();
         }
@@ -79,6 +80,17 @@ namespace ScriptableEvents.Tests.Runtime
             scriptableEvent.Raise(arg);
 
             Assert.AreEqual(1, capturedArgs.Count);
+        }
+        [Test]
+        public void ShouldListenToMultipleEvents()
+        {
+
+            scriptableEvent.Raise(arg);
+            scriptableEvent2.Raise(arg);
+
+            Assert.AreEqual(2, capturedArgs.Count);
+            Assert.AreEqual(arg, capturedArgs[0]);
+            Assert.AreEqual(arg, capturedArgs[1]);
         }
 
         [Test]
@@ -126,9 +138,10 @@ namespace ScriptableEvents.Tests.Runtime
             capturedArgs = new List<TArg>();
         }
 
-        private void SetupScriptableEvent()
+        private void SetupScriptableEvents()
         {
             scriptableEvent = ScriptableObject.CreateInstance<TScriptableEvent>();
+            scriptableEvent2 = ScriptableObject.CreateInstance<TScriptableEvent>();
         }
 
         private void SetupUnityEvent()
@@ -147,6 +160,7 @@ namespace ScriptableEvents.Tests.Runtime
             // Note: the type for scriptableEvents is NOT TScriptableEvent, it is BaseScriptableEvent<TArg>
             // If treated as TScriptableEvent, casting fails.
             scriptableEventListener.AddToListField<BaseScriptableEvent<TArg>>("scriptableEvents", scriptableEvent);
+            scriptableEventListener.AddToListField<BaseScriptableEvent<TArg>>("scriptableEvents", scriptableEvent2);
             scriptableEventListener.SetField("onRaised", unityEvent);
 
             // Add listener by triggering OnEnabled.

--- a/Packages/com.chark.scriptable-events/Tests/Runtime/ScriptableEventTest.cs
+++ b/Packages/com.chark.scriptable-events/Tests/Runtime/ScriptableEventTest.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using NUnit.Framework;
@@ -143,7 +143,10 @@ namespace ScriptableEvents.Tests.Runtime
             gameObject.SetActive(false);
 
             scriptableEventListener = gameObject.AddComponent<TScriptableEventListener>();
-            scriptableEventListener.SetField("scriptableEvent", scriptableEvent);
+
+            // Note: the type for scriptableEvents is NOT TScriptableEvent, it is BaseScriptableEvent<TArg>
+            // If treated as TScriptableEvent, casting fails.
+            scriptableEventListener.AddToListField<BaseScriptableEvent<TArg>>("scriptableEvents", scriptableEvent);
             scriptableEventListener.SetField("onRaised", unityEvent);
 
             // Add listener by triggering OnEnabled.


### PR DESCRIPTION
This changes listeners to accept multiple events (of a compatible type)
It replaces the existing listener/event mapping with a listener/List<event> mapping. 
The old event property is retained but concealed - I suggest it should be removed fully when the project next rolls major version (i.e. when a breaking change is reasonable to add)
A test has been added to make sure multi-event listening works for each event type.
The only shortfall I am aware of is that it does not check if you are in Editor mode (the detection of editor mode is not available during serialisation.)

I should note I have not tested this in an Odin-compatible environment.

I hope you find this useful.